### PR TITLE
Rename BrakeUp to BreakUp

### DIFF
--- a/BookFace/Hubs/FriendshipHub.cs
+++ b/BookFace/Hubs/FriendshipHub.cs
@@ -41,9 +41,9 @@ namespace BookFace.Hubs
             await Task.Run(async () => friendshipService.UnBlock(Context.User.Id(), friendId));
         }
 
-        public async Task SendBrakeUp(string friendId)
+        public async Task SendBreakUp(string friendId)
         {
-            await Task.Run(async () => friendshipService.BrakeUp(Context.User.Id(), friendId));
+            await Task.Run(async () => friendshipService.BreakUp(Context.User.Id(), friendId));
         }
     }
 }

--- a/BookFace/Services/Friendship/FriendshipService.cs
+++ b/BookFace/Services/Friendship/FriendshipService.cs
@@ -102,7 +102,7 @@ namespace BookFace.Services.Friendship
             return true;
         }
 
-        public bool BrakeUp(string firstId, string secondId)
+        public bool BreakUp(string firstId, string secondId)
         {
             var isPrepared = PrepareIds(ref firstId, ref secondId);
 

--- a/BookFace/Services/Friendship/IFriendshipService.cs
+++ b/BookFace/Services/Friendship/IFriendshipService.cs
@@ -18,7 +18,7 @@ namespace BookFace.Services.Friendship
 
         bool Deny(string firstId, string secondId);
 
-        bool BrakeUp(string firstId, string secondId);
+        bool BreakUp(string firstId, string secondId);
 
         Friendship CreateFriendship(string firstId, string secondId, FriendshipStatus firstStatus = FriendshipStatus.NoneAction, FriendshipStatus secondStatus = FriendshipStatus.NoneAction);
 

--- a/BookFace/Views/Friendships/All.cshtml
+++ b/BookFace/Views/Friendships/All.cshtml
@@ -28,7 +28,7 @@
                                     <input hidden value="@friend.Id" />
                                     @if (friendshipService.AreFriends(User.Id(), friend.Id))
                                     {
-                                        <button class="btn btn-outline-dark" value="BrakeUp">Brake up</button>
+                                        <button class="btn btn-outline-dark" value="BreakUp">Break up</button>
                                     }
                                     else if (friendshipService.CanRequest(User.Id(), friend.Id))
                                     {
@@ -93,8 +93,8 @@
     </div>
 </div>
 
-<script id="brakeUpTemplate" type="text/x-handlebars-template">
-    <button class="btn btn-outline-dark" value="BrakeUp">Brake up</button>
+<script id="breakUpTemplate" type="text/x-handlebars-template">
+    <button class="btn btn-outline-dark" value="BreakUp">Break up</button>
 </script>
 
 <script id="addFriendTemplate" type="text/x-handlebars-template">

--- a/BookFace/wwwroot/js/FriendshipPage.js
+++ b/BookFace/wwwroot/js/FriendshipPage.js
@@ -29,7 +29,7 @@ document.getElementById('buttons').addEventListener('click', e => {
             friendshipConnection.invoke('SendAccept', friendId)
                 .then(() => {
                     removeAcceptAndDeny(parent);
-                    let source = document.getElementById('brakeUpTemplate').innerHTML;
+                    let source = document.getElementById('breakUpTemplate').innerHTML;
                     let template = Handlebars.compile(source);
                     let resultHTML = template();
                     parent.innerHTML = resultHTML + parent.innerHTML;
@@ -45,8 +45,8 @@ document.getElementById('buttons').addEventListener('click', e => {
                     parent.innerHTML = resultHTML + parent.innerHTMLHTML;
                 });
             break;
-        case 'BrakeUp':
-            friendshipConnection.invoke('SendBrakeUp', friendId)
+        case 'BreakUp':
+            friendshipConnection.invoke('SendBreakUp', friendId)
                 .then(() => {
                     parent.removeChild(target);
                     let source = document.getElementById('addFriendTemplate').innerHTML;


### PR DESCRIPTION
## Summary
- rename friendship breakup methods from *BrakeUp* to *BreakUp*
- update Hub method to SendBreakUp
- align frontend and view with BreakUp nomenclature

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68909ffd2cb483219a513476f03245b4